### PR TITLE
Add basic veteran profile pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Compass4Vets is an in-progress web platform that helps U.S. veterans discover be
 - **Benefits assistant chat** for quick answers to questions
 - **Peer-to-peer forum and chat** to build community
 
+Veterans can create a basic profile via the Register page (`/register`).
+The saved information is shown on `/profile` and stored locally in the browser.
+
 ## Project Structure
 
 - `compass4vets-ui/` – Next.js front end

--- a/compass4vets-ui/src/app/layout.tsx
+++ b/compass4vets-ui/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Link from "next/link";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -24,9 +25,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <header className="flex items-center justify-between bg-gray-100 p-4">
+          <Link href="/" className="font-semibold">
+            Compass4Vets
+          </Link>
+          <nav className="flex gap-4">
+            <Link href="/register">Register</Link>
+            <Link href="/profile">Profile</Link>
+          </nav>
+        </header>
         {children}
       </body>
     </html>

--- a/compass4vets-ui/src/app/profile/page.tsx
+++ b/compass4vets-ui/src/app/profile/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface Profile {
+  name: string;
+  branch: string;
+  years: string;
+  interests: string;
+  needs: string;
+}
+
+export default function ProfilePage() {
+  const [profile, setProfile] = useState<Profile | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("profile");
+      if (stored) {
+        setProfile(JSON.parse(stored));
+      }
+    }
+  }, []);
+
+  if (!profile) {
+    return (
+      <div className="p-6">
+        <h1 className="text-xl font-bold mb-4">No profile found</h1>
+        <Link href="/register" className="text-blue-600 underline">
+          Create your profile
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-xl p-6 space-y-2">
+      <h1 className="text-2xl font-bold mb-4">Your Profile</h1>
+      <p>
+        <strong>Name:</strong> {profile.name}
+      </p>
+      <p>
+        <strong>Branch of Service:</strong> {profile.branch}
+      </p>
+      <p>
+        <strong>Years of Service:</strong> {profile.years}
+      </p>
+      <p>
+        <strong>Interests:</strong> {profile.interests}
+      </p>
+      <p>
+        <strong>Needs:</strong> {profile.needs}
+      </p>
+      <Button asChild>
+        <Link href="/register">Edit Profile</Link>
+      </Button>
+    </div>
+  );
+}

--- a/compass4vets-ui/src/app/register/page.tsx
+++ b/compass4vets-ui/src/app/register/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState, FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [branch, setBranch] = useState("");
+  const [years, setYears] = useState("");
+  const [interests, setInterests] = useState("");
+  const [needs, setNeeds] = useState("");
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const profile = { name, branch, years, interests, needs };
+    if (typeof window !== "undefined") {
+      localStorage.setItem("profile", JSON.stringify(profile));
+    }
+    router.push("/profile");
+  }
+
+  return (
+    <div className="mx-auto max-w-xl p-6">
+      <h1 className="text-2xl font-bold mb-4">Create Your Profile</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
+        <Input placeholder="Branch of Service" value={branch} onChange={(e) => setBranch(e.target.value)} />
+        <Input placeholder="Years of Service" value={years} onChange={(e) => setYears(e.target.value)} />
+        <textarea
+          placeholder="Interests"
+          value={interests}
+          onChange={(e) => setInterests(e.target.value)}
+          className="w-full rounded-md border border-gray-300 p-2"
+        />
+        <textarea
+          placeholder="Needs"
+          value={needs}
+          onChange={(e) => setNeeds(e.target.value)}
+          className="w-full rounded-md border border-gray-300 p-2"
+        />
+        <Button type="submit">Save Profile</Button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support registration of a veteran profile
- display saved profile info
- add navigation links for Register and Profile pages
- document new feature in README

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683f3fb184648327afb14552b0d360f7