### PR TITLE
Improve services page with search and request modal

### DIFF
--- a/compass4vets-ui/src/app/services/page.tsx
+++ b/compass4vets-ui/src/app/services/page.tsx
@@ -1,37 +1,157 @@
-import React from 'react';
+"use client";
+
+import React, { useMemo, useState } from 'react';
 import ServiceCard from '@/components/services/ServiceCard';
 import servicesData from '@/data/services.json';
 import { Service } from '@/types/service';
+import RequestServiceModal from '@/components/services/RequestServiceModal';
+import {
+  Stethoscope,
+  GraduationCap,
+  Briefcase,
+  Home,
+  Gavel,
+  Banknote,
+  Users,
+  Info,
+} from 'lucide-react';
 
 export default function ServicesPage() {
   const services: Service[] = servicesData;
+  const [search, setSearch] = useState('');
+  const [category, setCategory] = useState<string>('All');
+  const [selectedService, setSelectedService] = useState<Service | null>(null);
+
+  const categories = useMemo(() => {
+    const cats = Array.from(new Set(services.map((s) => s.category)));
+    return ['All', ...cats];
+  }, [services]);
+
+  const groups: Record<string, string[]> = {
+    'Healthcare & Mental Health': ['Healthcare'],
+    'Housing & Financial Aid': ['Housing', 'Financial'],
+    'Education & Career': ['Education', 'Employment'],
+    'Legal Support': ['Legal'],
+    'Community & Recreation': ['Social & Community'],
+  };
+
+  const categoryIcons: Record<string, any> = {
+    Healthcare: Stethoscope,
+    Education: GraduationCap,
+    Employment: Briefcase,
+    Housing: Home,
+    Legal: Gavel,
+    Financial: Banknote,
+    'Social & Community': Users,
+    Other: Info,
+  };
+
+  const filteredServices = services.filter((s) => {
+    const matchesCategory = category === 'All' || s.category === category;
+    const searchText = search.toLowerCase();
+    const matchesSearch = s.name.toLowerCase().includes(searchText) ||
+      (s.shortDescription && s.shortDescription.toLowerCase().includes(searchText));
+    return matchesCategory && matchesSearch;
+  });
+
+  const groupedServices = useMemo(() => {
+    const searchText = search.toLowerCase();
+    const result: Record<string, Service[]> = {};
+    Object.entries(groups).forEach(([label, cats]) => {
+      result[label] = services.filter(
+        (s) =>
+          cats.includes(s.category) &&
+          (s.name.toLowerCase().includes(searchText) ||
+            (s.shortDescription && s.shortDescription.toLowerCase().includes(searchText)))
+      );
+    });
+    return result;
+  }, [services, search]);
 
   return (
     <main className="min-h-screen py-12 px-4 sm:px-6 lg:px-8 bg-background text-foreground">
       <div className="container mx-auto">
-        <header className="mb-12 text-center">
-          <h1 className="text-4xl font-extrabold tracking-tight sm:text-5xl md:text-6xl text-primary">
+        <header className="mb-6 text-center sticky top-0 bg-background z-10 py-4">
+          <h1 className="text-3xl sm:text-4xl font-extrabold tracking-tight text-primary mb-4">
             Veteran Services Directory
           </h1>
-          <p className="mt-3 max-w-md mx-auto text-base text-muted-foreground sm:text-lg md:mt-5 md:text-xl md:max-w-3xl">
-            Find resources and support services tailored for veterans. Browse by category or search for specific needs.
-          </p>
+          <nav className="mb-4 flex flex-wrap justify-center gap-3 text-sm">
+            {Object.keys(groups).map((label) => (
+              <a key={label} href={`#${label.replace(/\s+/g, '-').toLowerCase()}`} className="underline text-primary hover:text-primary/80">
+                {label}
+              </a>
+            ))}
+          </nav>
+          <div className="flex flex-wrap justify-center gap-2 mb-4">
+            {categories.map((cat) => (
+              <button
+                key={cat}
+                className={`px-3 py-1 rounded-md text-sm border ${category === cat ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground'} hover:bg-primary/80 hover:text-primary-foreground`}
+                onClick={() => setCategory(cat)}
+              >
+                {cat}
+              </button>
+            ))}
+          </div>
+          <input
+            type="text"
+            placeholder="Search services..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full max-w-md mx-auto px-3 py-2 border rounded-md"
+          />
         </header>
 
-        {services.length > 0 ? (
+        {category === 'All' ? (
+          Object.entries(groupedServices).map(([label, list]) => (
+            <section key={label} id={label.replace(/\s+/g, '-').toLowerCase()} className="mb-12">
+              <h2 className="text-2xl font-bold mb-4 flex items-center gap-2">
+                {label}
+              </h2>
+              {list.length > 0 ? (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+                  {list.map((service) => {
+                    const IconComp = categoryIcons[service.category] || Info;
+                    return (
+                      <ServiceCard
+                        key={service.id}
+                        service={service}
+                        onRequest={() => setSelectedService(service)}
+                        CategoryIcon={IconComp}
+                      />
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="text-muted-foreground">No services available.</p>
+              )}
+            </section>
+          ))
+        ) : filteredServices.length > 0 ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-            {services.map((service) => (
-              <ServiceCard key={service.id} service={service} />
-            ))}
+            {filteredServices.map((service) => {
+              const IconComp = categoryIcons[service.category] || Info;
+              return (
+                <ServiceCard
+                  key={service.id}
+                  service={service}
+                  onRequest={() => setSelectedService(service)}
+                  CategoryIcon={IconComp}
+                />
+              );
+            })}
           </div>
         ) : (
           <div className="text-center py-12">
-            <p className="text-xl text-muted-foreground">
-              No services are currently listed. Please check back soon.
-            </p>
+            <p className="text-xl text-muted-foreground">No matching services found.</p>
           </div>
         )}
       </div>
+      <RequestServiceModal
+        serviceName={selectedService?.name || ''}
+        isOpen={!!selectedService}
+        onClose={() => setSelectedService(null)}
+      />
     </main>
   );
 }

--- a/compass4vets-ui/src/components/services/RequestServiceModal.tsx
+++ b/compass4vets-ui/src/components/services/RequestServiceModal.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+
+interface RequestServiceModalProps {
+  serviceName: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function RequestServiceModal({ serviceName, isOpen, onClose }: RequestServiceModalProps) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+
+  if (!isOpen) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Placeholder: Replace with real submission logic
+    alert(`Request sent for ${serviceName}`);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="bg-background text-foreground rounded-lg w-full max-w-md p-6 shadow-lg">
+        <h2 className="text-xl font-semibold mb-4">Request {serviceName}</h2>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <Input placeholder="Your Name" value={name} onChange={(e) => setName(e.target.value)} required />
+          <Input type="email" placeholder="Your Email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+          <Textarea placeholder="How can we help?" rows={3} value={message} onChange={(e) => setMessage(e.target.value)} />
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={onClose}>Cancel</Button>
+            <Button type="submit">Send Request</Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/compass4vets-ui/src/components/services/ServiceCard.tsx
+++ b/compass4vets-ui/src/components/services/ServiceCard.tsx
@@ -1,25 +1,33 @@
+"use client";
+
 import React from 'react';
 import Image from 'next/image';
+import { Icon } from 'lucide-react';
 import { Service } from '@/types/service'; // Assuming '@/' is an alias for 'src/'
 
 interface ServiceCardProps {
   service: Service;
+  onRequest?: (service: Service) => void;
+  CategoryIcon?: Icon;
 }
 
-const ServiceCard: React.FC<ServiceCardProps> = ({ service }) => {
+const ServiceCard: React.FC<ServiceCardProps> = ({ service, onRequest, CategoryIcon }) => {
   return (
     <div className="bg-card text-card-foreground rounded-lg border border-border p-6 shadow-lg hover:shadow-xl transition-shadow duration-300 ease-in-out flex flex-col h-full">
       {service.logoUrl && (
         <div className="relative h-24 w-full mb-4 flex justify-center items-center">
-          <Image 
-            src={service.logoUrl} 
-            alt={`${service.name} logo`} 
+          <Image
+            src={service.logoUrl}
+            alt={`${service.name} logo`}
             width={80} // Provide explicit width
             height={80} // Provide explicit height
-            objectFit="contain" 
+            objectFit="contain"
             className="rounded-md"
           />
         </div>
+      )}
+      {CategoryIcon && (
+        <CategoryIcon className="text-primary mb-2 h-6 w-6" />
       )}
       <h3 className="text-xl font-semibold mb-2 text-primary group-hover:text-primary-hover transition-colors">
         {service.name}
@@ -36,13 +44,12 @@ const ServiceCard: React.FC<ServiceCardProps> = ({ service }) => {
       <p className="text-sm text-muted-foreground mb-4 flex-grow">
         {service.shortDescription || service.description.substring(0, 150) + (service.description.length > 150 ? '...' : '')}
       </p>
-      {/* Placeholder for a 'Learn More' link/button */}
-      {/* <a 
-        href={`/services/${service.id}`} 
-        className="mt-auto text-sm font-semibold text-accent hover:text-accent-hover self-start"
+      <button
+        onClick={() => onRequest?.(service)}
+        className="mt-auto px-4 py-2 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90"
       >
-        Learn More &rarr;
-      </a> */}
+        Request Service
+      </button>
     </div>
   );
 };

--- a/compass4vets-ui/src/data/services.json
+++ b/compass4vets-ui/src/data/services.json
@@ -91,5 +91,371 @@
     "eligibility": "Low-income veterans with qualifying legal issues.",
     "keywords": ["lawyer", "attorney", "pro bono", "VA benefits appeal", "eviction"],
     "operatingHours": "Intake line open Mon, Wed, Fri, 10:00 AM - 2:00 PM"
+  },
+  {
+    "id": "health-mindful-warrior",
+    "name": "Mindful Warrior Counseling",
+    "category": "Healthcare",
+    "shortDescription": "Confidential mental health counseling and peer support groups for veterans.",
+    "description": "Mindful Warrior offers therapy sessions, crisis counseling, and weekly peer-led groups focused on PTSD, depression, and anxiety management.",
+    "contactInfo": {
+      "phone": "555-0404",
+      "website": "https://demo.example.com/mindful-warrior"
+    },
+    "address": {
+      "city": "Centerville",
+      "state": "CO"
+    },
+    "operatingHours": "Mon-Sat, 9:00 AM - 8:00 PM",
+    "keywords": ["counseling", "therapy", "support group"]
+  },
+  {
+    "id": "finance-grants-aid",
+    "name": "Veteran Grants Assistance",
+    "category": "Financial",
+    "shortDescription": "Help applying for small grants and financial relief programs.",
+    "description": "Veteran Grants Assistance guides veterans through the paperwork needed for emergency grants, utility help, and other short-term financial aid.",
+    "contactInfo": {
+      "email": "info@grantsaid.org",
+      "website": "https://demo.example.com/grants-aid"
+    },
+    "address": {
+      "details": "Nationwide"
+    },
+    "keywords": ["grants", "financial aid", "emergency"]
+  },
+  {
+    "id": "community-vet-sports",
+    "name": "Veteran Adaptive Sports Club",
+    "category": "Social & Community",
+    "shortDescription": "Weekly adaptive sports and recreation events for wounded veterans.",
+    "description": "The club organizes local leagues and outings for veterans with disabilities, promoting physical health and camaraderie.",
+    "contactInfo": {
+      "phone": "555-0505"
+    },
+    "address": {
+      "city": "Lakeview",
+      "state": "FL"
+    },
+    "keywords": ["sports", "recreation", "community"]
+  },
+  {
+    "id": "education-scholarship-fund",
+    "name": "Heroes Scholarship Fund",
+    "category": "Education",
+    "shortDescription": "Tuition assistance for veterans pursuing undergraduate degrees.",
+    "description": "Heroes Scholarship Fund awards annual scholarships to veterans enrolled in accredited colleges and universities.",
+    "contactInfo": {
+      "website": "https://demo.example.com/heroes-scholarship",
+      "email": "apply@heroes-scholarship.org"
+    },
+    "address": {
+      "details": "Nationwide"
+    },
+    "keywords": ["scholarship", "tuition", "college"]
+  },
+  {
+    "id": "employment-career-fair",
+    "name": "National Veteran Career Fair",
+    "category": "Employment",
+    "shortDescription": "Annual job fair connecting veterans with major employers.",
+    "description": "The National Veteran Career Fair features workshops, resume reviews, and on-site interviews with companies committed to hiring veterans.",
+    "contactInfo": {
+      "website": "https://demo.example.com/vet-career-fair"
+    },
+    "address": {
+      "city": "Washington",
+      "state": "DC"
+    },
+    "keywords": ["job fair", "employment", "workshop"]
+  },
+  {
+    "id": "housing-rural-assist",
+    "name": "Rural Housing Outreach",
+    "category": "Housing",
+    "shortDescription": "Mobile team helping rural veterans access safe housing and VA loans.",
+    "description": "Rural Housing Outreach travels to underserved counties providing housing counseling and assistance with VA loan applications.",
+    "contactInfo": {
+      "phone": "555-0606"
+    },
+    "address": {
+      "details": "Service vans visit multiple states"
+    },
+    "keywords": ["rural", "VA loan", "housing counseling"]
+  },
+  {
+    "id": "legal-benefits-hotline",
+    "name": "Benefits Appeal Hotline",
+    "category": "Legal",
+    "shortDescription": "Phone line staffed by attorneys for VA benefits appeals.",
+    "description": "This hotline answers questions about denied claims and can connect callers with accredited representatives for formal appeals.",
+    "contactInfo": {
+      "phone": "555-0707"
+    },
+    "address": {
+      "details": "Nationwide"
+    },
+    "operatingHours": "Mon-Fri, 9:00 AM - 4:00 PM",
+    "keywords": ["benefits", "appeal", "claims"]
+  },
+  {
+    "id": "finance-credit-counsel",
+    "name": "Credit Counseling for Veterans",
+    "category": "Financial",
+    "shortDescription": "Free credit checks and budgeting workshops.",
+    "description": "Certified counselors help veterans repair credit and plan budgets to achieve long-term financial stability.",
+    "contactInfo": {
+      "email": "support@vetcredit.org"
+    },
+    "address": {
+      "city": "Columbus",
+      "state": "OH"
+    },
+    "keywords": ["credit", "budget", "finance"]
+  },
+  {
+    "id": "community-family-retreat",
+    "name": "Family Reintegration Retreats",
+    "category": "Social & Community",
+    "shortDescription": "Weekend retreats focused on reconnecting veterans with their families.",
+    "description": "Counselors and peer mentors facilitate activities that help families adjust after deployments and long separations.",
+    "contactInfo": {
+      "website": "https://demo.example.com/family-retreat"
+    },
+    "address": {
+      "state": "UT"
+    },
+    "keywords": ["family", "retreat", "reintegration"]
+  },
+  {
+    "id": "education-skillbridge",
+    "name": "SkillBridge Prep Center",
+    "category": "Education",
+    "shortDescription": "Workshops preparing service members for DoD SkillBridge internships.",
+    "description": "This center offers resume help and industry briefings so veterans can make the most of SkillBridge opportunities before separation.",
+    "contactInfo": {
+      "phone": "555-0808"
+    },
+    "address": {
+      "city": "Fayetteville",
+      "state": "NC"
+    },
+    "keywords": ["skillbridge", "transition", "internship"]
+  },
+  {
+    "id": "employment-remote-jobs",
+    "name": "Remote Veterans Work Hub",
+    "category": "Employment",
+    "shortDescription": "Database of vetted remote job openings for veterans.",
+    "description": "The Work Hub curates remote-friendly employers and provides interview coaching tailored for virtual roles.",
+    "contactInfo": {
+      "email": "jobs@remotevets.org"
+    },
+    "address": {
+      "details": "Online Only"
+    },
+    "keywords": ["remote", "telework", "virtual"]
+  },
+  {
+    "id": "housing-transitional-center",
+    "name": "Transitional Housing Center",
+    "category": "Housing",
+    "shortDescription": "Short-term housing with counseling and job training on-site.",
+    "description": "This center offers dorm-style rooms for up to six months while veterans secure employment and permanent housing.",
+    "contactInfo": {
+      "phone": "555-0909"
+    },
+    "address": {
+      "city": "Chicago",
+      "state": "IL"
+    },
+    "keywords": ["transitional", "shelter", "training"]
+  },
+  {
+    "id": "legal-discharge-upgrade",
+    "name": "Discharge Upgrade Project",
+    "category": "Legal",
+    "shortDescription": "Assistance filing for discharge upgrades and record corrections.",
+    "description": "Volunteer attorneys review service records and help prepare applications to military review boards.",
+    "contactInfo": {
+      "website": "https://demo.example.com/discharge-upgrade"
+    },
+    "address": {
+      "details": "Nationwide"
+    },
+    "keywords": ["discharge", "upgrade", "records"]
+  },
+  {
+    "id": "health-telemedicine",
+    "name": "Vet Telemedicine Portal",
+    "category": "Healthcare",
+    "shortDescription": "Video appointments with VA doctors from home.",
+    "description": "The portal connects veterans to licensed practitioners for routine consultations and prescription renewals without travel.",
+    "contactInfo": {
+      "website": "https://demo.example.com/telemedicine"
+    },
+    "address": {
+      "details": "Nationwide"
+    },
+    "keywords": ["telehealth", "virtual", "doctor"]
+  },
+  {
+    "id": "education-certification-grants",
+    "name": "Certification Grant Program",
+    "category": "Education",
+    "shortDescription": "Covers testing fees for professional certifications.",
+    "description": "Veterans can apply for reimbursement of exam costs for IT, project management, and other career certifications.",
+    "contactInfo": {
+      "email": "grants@certvets.org"
+    },
+    "address": {
+      "details": "Nationwide"
+    },
+    "keywords": ["certification", "exam", "reimbursement"]
+  },
+  {
+    "id": "employment-startup-lab",
+    "name": "Veteran Startup Lab",
+    "category": "Employment",
+    "shortDescription": "Incubator program for veteran-owned small businesses.",
+    "description": "Provides mentorship, workspace, and seed funding competitions to help veterans launch entrepreneurial ventures.",
+    "contactInfo": {
+      "website": "https://demo.example.com/startup-lab"
+    },
+    "address": {
+      "city": "San Diego",
+      "state": "CA"
+    },
+    "keywords": ["entrepreneur", "business", "startup"]
+  },
+  {
+    "id": "housing-home-mods",
+    "name": "Accessible Home Modifications",
+    "category": "Housing",
+    "shortDescription": "Grants to adapt homes for mobility-impaired veterans.",
+    "description": "Certified contractors install ramps, widen doorways, and improve safety so veterans can live independently.",
+    "contactInfo": {
+      "phone": "555-1010"
+    },
+    "address": {
+      "details": "Nationwide"
+    },
+    "keywords": ["accessibility", "home", "modification"]
+  },
+  {
+    "id": "community-vet-art",
+    "name": "Veterans Art Collective",
+    "category": "Social & Community",
+    "shortDescription": "Creative workshops and gallery shows featuring veteran artists.",
+    "description": "Weekly classes in painting, music, and writing culminate in community exhibitions that celebrate veterans' voices.",
+    "contactInfo": {
+      "email": "info@vetartcollective.org"
+    },
+    "address": {
+      "city": "Portland",
+      "state": "OR"
+    },
+    "keywords": ["art", "workshop", "community"]
+  },
+  {
+    "id": "finance-loan-counsel",
+    "name": "VA Loan Counseling Network",
+    "category": "Financial",
+    "shortDescription": "Guidance on VA home loans and refinancing options.",
+    "description": "Certified counselors explain eligibility and help veterans compare lenders for the best rates.",
+    "contactInfo": {
+      "phone": "555-1111"
+    },
+    "address": {
+      "city": "Phoenix",
+      "state": "AZ"
+    },
+    "keywords": ["VA loan", "mortgage", "refinance"]
+  },
+  {
+    "id": "community-volunteer-corps",
+    "name": "Veteran Volunteer Corps",
+    "category": "Social & Community",
+    "shortDescription": "Connects veterans with local volunteer opportunities.",
+    "description": "From disaster relief to mentoring youth, the corps organizes service projects that keep veterans engaged in their communities.",
+    "contactInfo": {
+      "website": "https://demo.example.com/volunteer-corps"
+    },
+    "address": {
+      "details": "Nationwide"
+    },
+    "keywords": ["volunteer", "community", "service"]
+  },
+  {
+    "id": "education-online-university",
+    "name": "Veterans Online University",
+    "category": "Education",
+    "shortDescription": "Self-paced courses in business, health, and technology.",
+    "description": "This accredited online program offers discounts for veterans and accepts GI Bill benefits.",
+    "contactInfo": {
+      "website": "https://demo.example.com/online-university"
+    },
+    "address": {
+      "details": "Online Only"
+    },
+    "keywords": ["online", "degree", "gi bill"]
+  },
+  {
+    "id": "employment-apprenticeship",
+    "name": "Trades Apprenticeship Program",
+    "category": "Employment",
+    "shortDescription": "Paid apprenticeships in plumbing, electrical, and carpentry trades.",
+    "description": "Partner unions sponsor apprenticeships exclusively for veterans, combining classroom learning with paid on-the-job training.",
+    "contactInfo": {
+      "phone": "555-1212"
+    },
+    "address": {
+      "city": "Detroit",
+      "state": "MI"
+    },
+    "keywords": ["apprenticeship", "trades", "training"]
+  },
+  {
+    "id": "legal-tax-clinic",
+    "name": "Veterans Tax Law Clinic",
+    "category": "Legal",
+    "shortDescription": "Assistance with IRS disputes and tax return preparation.",
+    "description": "Law students and supervising attorneys help veterans resolve tax issues and claim eligible deductions.",
+    "contactInfo": {
+      "email": "clinic@vettaxlaw.org"
+    },
+    "address": {
+      "city": "Boston",
+      "state": "MA"
+    },
+    "keywords": ["tax", "IRS", "clinic"]
+  },
+  {
+    "id": "housing-energy-assist",
+    "name": "Energy Assistance Program",
+    "category": "Housing",
+    "shortDescription": "Utility bill help for low-income veteran households.",
+    "description": "Seasonal grants help cover heating and cooling costs to ensure veterans can stay in their homes.",
+    "contactInfo": {
+      "phone": "555-1313"
+    },
+    "address": {
+      "state": "NV"
+    },
+    "keywords": ["utility", "bill", "energy"]
+  },
+  {
+    "id": "community-peer-network",
+    "name": "Peer Mentor Network",
+    "category": "Social & Community",
+    "shortDescription": "Matches new veterans with local peer mentors for guidance.",
+    "description": "Experienced veterans volunteer as mentors to help newcomers navigate civilian life, benefits, and community resources.",
+    "contactInfo": {
+      "email": "mentors@peernetwork.org"
+    },
+    "address": {
+      "details": "Nationwide"
+    },
+    "keywords": ["mentor", "peer", "support"]
   }
 ]


### PR DESCRIPTION
## Summary
- greatly expand `services.json` with demo data (30 total items)
- add `RequestServiceModal` for simple contact requests
- enhance `ServiceCard` with icon slot and request button
- rework services page with search bar, category tabs, grouped sections and modal support

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68407979145c8327a7bf1964fcf44a9a